### PR TITLE
Use only SRD equipment for generated characters

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Um módulo para Foundry Virtual Tabletop que permite gerar personagens automatic
 - **Geração Automática**: Cria personagens com atributos aleatórios usando 3d6
 - **Múltiplas Raças**: Suporte para Humanos, Elfos, Anões, Halflings, Orcs e Goblins
 - **Todas as Classes**: Guerreiro, Mago, Clérigo, Ladino, Druida, Paladino e Ranger
-- **Equipamento Automático**: Cada classe recebe equipamento apropriado
+- **Equipamento Automático**: Cada classe recebe equipamento apropriado buscado exclusivamente no compêndio oficial do sistema
 - **Cálculo de HP**: Pontos de vida calculados automaticamente baseado na classe e constituição
 - **Interface Intuitiva**: Botão integrado no menu de atores do Foundry VTT
 

--- a/scripts/character-generator.js
+++ b/scripts/character-generator.js
@@ -563,32 +563,32 @@ class OldDragon2eCharacterGenerator {
     generateEquipment(characterClass) {
         const baseEquipment = {
             fighter: [
-                'Espada longa', 'Escudo', 'Armadura de couro', 'Mochila', 'Rações (3 dias)',
-                'Corda (15m)', 'Tochas (6)', 'Pederneira e aço', 'Pote de ferro', 'Tenda'
+                'Espada Longa', 'Escudo', 'Armadura de Couro', 'Mochila', 'Ração de viagem (3)',
+                'Corda de Cânhamo', 'Tocha (6)', 'Pederneira', 'Tenda pequena', 'Saco de Dormir'
             ],
             mage: [
-                'Cajado', 'Túnica', 'Mochila', 'Pergaminhos', 'Tinta e pena',
-                'Vela (3)', 'Rações (2 dias)', 'Garrafa de água', 'Saco de dormir'
+                'Bordão/Cajado', 'Mochila', 'Pergaminho (3)', 'Pena e Tinta',
+                'Vela (3)', 'Ração de viagem (2)', 'Odre', 'Saco de Dormir'
             ],
             cleric: [
-                'Martelo de guerra', 'Escudo', 'Armadura de couro', 'Símbolo sagrado',
-                'Mochila', 'Rações (3 dias)', 'Garrafa de água', 'Vela (3)'
+                'Martelo de Batalha', 'Escudo', 'Armadura de Couro', 'Símbolo divino',
+                'Mochila', 'Ração de viagem (3)', 'Odre', 'Vela (3)'
             ],
             thief: [
-                'Adaga (2)', 'Arco curto', 'Flechas (20)', 'Armadura de couro',
-                'Mochila', 'Corda (15m)', 'Gancho de escalada', 'Rações (2 dias)'
+                'Adaga (2)', 'Arco Curto', 'Flecha de Guerra (20)', 'Armadura de Couro',
+                'Mochila', 'Corda de Cânhamo', 'Cravos/Ganchos', 'Ração de viagem (2)'
             ],
             druid: [
-                'Bastão', 'Armadura de couro', 'Mochila', 'Símbolo natural',
-                'Rações (3 dias)', 'Garrafa de água', 'Saco de dormir', 'Tochas (3)'
+                'Bordão/Cajado', 'Armadura de Couro', 'Mochila', 'Símbolo divino',
+                'Ração de viagem (3)', 'Odre', 'Saco de Dormir', 'Tocha (3)'
             ],
             paladin: [
-                'Espada longa', 'Escudo', 'Armadura de couro', 'Símbolo sagrado',
-                'Mochila', 'Rações (3 dias)', 'Garrafa de água', 'Tochas (3)'
+                'Espada Longa', 'Escudo', 'Armadura de Couro', 'Símbolo divino',
+                'Mochila', 'Ração de viagem (3)', 'Odre', 'Tocha (3)'
             ],
             ranger: [
-                'Espada curta', 'Arco longo', 'Flechas (20)', 'Armadura de couro',
-                'Mochila', 'Rações (3 dias)', 'Corda (15m)', 'Tochas (3)'
+                'Espada Curta', 'Arco Longo', 'Flecha de Guerra (20)', 'Armadura de Couro',
+                'Mochila', 'Ração de viagem (3)', 'Corda de Cânhamo', 'Tocha (3)'
             ]
         };
 
@@ -1286,23 +1286,7 @@ class OldDragon2eCharacterGenerator {
 
                         if (allow) itemsToCreate.push(itemData);
                     } else {
-                        // Sem documento no compêndio: aplica heurísticas de restrição antes de criar genérico
-                        const lower = baseName.toLowerCase();
-                        let allow = true;
-                        if (/escudo|shield/.test(lower) && !restrictions.shield) allow = false;
-                        if (/armadura|armor/.test(lower)) {
-                            if (restrictions.armor === 'none') allow = false;
-                            if (restrictions.armor === 'light' && !this.patterns.leatherArmor.test(lower)) allow = false;
-                            if (restrictions.leatherOnly && !this.patterns.leatherArmor.test(lower)) allow = false;
-                        }
-                        if (/espada|lan[cç]a|adaga|punhal|faca|arco|flecha|ma[cç]a|mangual|martelo|porrete|clava|cajado|bast[aã]o|machado|alabarda|glaive|montante/.test(lower)) {
-                            if (restrictions.onlyImpact && !this.patterns.impactWeapons.test(lower)) allow = false;
-                            if (restrictions.onlySmall && !this.patterns.smallWeapons.test(lower)) allow = false;
-                            if (restrictions.noLarge && this.patterns.twoHandedHints.test(lower)) allow = false;
-                        }
-                        if (allow) {
-                            itemsToCreate.push({ name: baseName, type: 'misc', system: { quantity } });
-                        }
+                        console.warn(`Item não encontrado no SRD: ${baseName}`);
                     }
                 }
 


### PR DESCRIPTION
## Summary
- ensure generated characters only use equipment defined in the official SRD pack
- warn when requested gear is missing instead of creating generic items
- document that equipment comes from the official SRD compendium

## Testing
- `node -e "const fs=require('fs'); const vm=require('vm'); const code=fs.readFileSync('scripts/character-generator.js','utf8'); const sandbox={console, Hooks:{on(){}}}; vm.createContext(sandbox); vm.runInContext(code + ';this.OldDragon2eCharacterGenerator = OldDragon2eCharacterGenerator;', sandbox); const gen=new sandbox.OldDragon2eCharacterGenerator(); console.log('fighter', gen.generateEquipment('fighter')); console.log('mage', gen.generateEquipment('mage')); console.log('cleric', gen.generateEquipment('cleric')); console.log('thief', gen.generateEquipment('thief')); console.log('druid', gen.generateEquipment('druid')); console.log('paladin', gen.generateEquipment('paladin')); console.log('ranger', gen.generateEquipment('ranger'));"`
- `node test/test-module.js` (fails: window is not defined)


------
https://chatgpt.com/codex/tasks/task_e_68b9e435cef48322a7bd7c4a4a194f7e