### PR TITLE
feat: Extract abilities directly from Old Dragon 2e SRD compendium

### DIFF
--- a/scripts/character-generator.js
+++ b/scripts/character-generator.js
@@ -760,6 +760,7 @@ class OldDragon2eCharacterGenerator {
         else if (/bruxo|warlock|feiticeiro/i.test(classNameLower)) {
             if (level >= 1) {
                 abilities.push('Iniciado: Conjura magias 1º círculo, pode usar armas médias e armaduras leves (mesmo metal) sem prejudicar rituais');
+                abilities.push('Metal: Objetos de metal atrapalham canalização (1-2 em 1d6 chance de perder ritual)');
             }
             if (level >= 3) {
                 abilities.push('Médium: Conjura magias 2º círculo, pode usar armas grandes (mesmo metal) sem prejudicar rituais');
@@ -768,7 +769,7 @@ class OldDragon2eCharacterGenerator {
                 abilities.push('Conjurador: Conjura magias 3º círculo, pode usar armaduras médias (mesmo metal) sem prejudicar rituais');
             }
             if (level >= 10) {
-                abilities.push('Entidade: Conjura magias 4º-6º círculos, pode usar todas armaduras/armas (mesmo metal) sem prejudicar rituais');
+                abilities.push('Entidade: Conjura magias 4º-6º círculos, pode usar todas armaduras e armas (mesmo metal) sem prejudicar rituais');
             }
         }
         

--- a/scripts/character-generator.js
+++ b/scripts/character-generator.js
@@ -647,16 +647,16 @@ class OldDragon2eCharacterGenerator {
         // Xamã (Clérigo)
         else if (/xamã|shaman/i.test(classNameLower)) {
             if (level >= 1) {
-                abilities.push('Comunhão Espiritual: Contato com espíritos');
+                abilities.push('Animal Sagrado: Seleciona animal/criatura como símbolo divino, seguidores fazem ataques fáceis durante canções sagradas');
             }
             if (level >= 3) {
-                abilities.push('Visões: Recebe visões proféticas');
+                abilities.push('Cura Totêmica: Troca magia preparada por Curar Ferimentos 1º círculo (1d8 PV)');
             }
             if (level >= 6) {
-                abilities.push('Possessão: Espíritos podem possuir aliados');
+                abilities.push('Fúria: Cantoria sagrada estimula aliado a entrar em fúria (dado de dano superior, ataques muito fáceis, alvo fácil para inimigos)');
             }
             if (level >= 10) {
-                abilities.push('Ascensão: Transforma-se em espírito');
+                abilities.push('Fúria da Natureza: Troca magia 5º círculo por Controlar o Clima 7º círculo (mesmo sem acesso a magias 7º círculo)');
             }
         }
         

--- a/scripts/character-generator.js
+++ b/scripts/character-generator.js
@@ -310,7 +310,7 @@ class OldDragon2eCharacterGenerator {
     /**
      * Obtém as habilidades de classe do SRD
      */
-    getClassAbilitiesFromSRD(selectedClass) {
+    getClassAbilitiesFromSRD(selectedClass, level = 1) {
         try {
             // Tenta extrair habilidades do sistema da classe do SRD
             const classData = selectedClass.system;
@@ -333,6 +333,10 @@ class OldDragon2eCharacterGenerator {
                     }
                 });
             }
+            
+            // Adiciona habilidades específicas de especializações por nível
+            const specializationAbilities = this.getSpecializationAbilities(selectedClass.name, level);
+            abilities.push(...specializationAbilities);
             
             // Se não encontrou habilidades no SRD, usa as habilidades locais como fallback
             if (abilities.length === 0) {
@@ -503,6 +507,64 @@ class OldDragon2eCharacterGenerator {
         
         // Fallback genérico
         return ['Habilidades específicas da classe'];
+    }
+
+    /**
+     * Obtém habilidades específicas de especializações por nível
+     */
+    getSpecializationAbilities(className, level = 1) {
+        const classNameLower = className.toLowerCase();
+        const abilities = [];
+        
+        // Elfo Aventureiro (Mago)
+        if (/elfo aventureiro|elf adventurer/i.test(classNameLower)) {
+            if (level >= 1) {
+                abilities.push('Treinamento Racial: +1 PV por nível, sem restrições de armas/armaduras, +2 dano com arma racial');
+            }
+            if (level >= 3) {
+                abilities.push('Brilho Mágico: Conjura 1 magia de 1º círculo por dia');
+            }
+            if (level >= 6) {
+                abilities.push('Esplendor Arcano: Lança magias como Mago 5 níveis abaixo');
+            }
+            if (level >= 10) {
+                abilities.push('Ataque Extra: Segundo ataque com arma racial');
+            }
+        }
+        
+        // Anão Aventureiro (Guerreiro)
+        else if (/anão aventureiro|anao aventureiro|dwarf adventurer/i.test(classNameLower)) {
+            if (level >= 1) {
+                abilities.push('Treinamento Racial: Mantém habilidades raciais de anão');
+            }
+            if (level >= 3) {
+                abilities.push('Resistência a Venenos: +2 em testes contra venenos');
+            }
+            if (level >= 6) {
+                abilities.push('Conhecimento de Pedras e Metais: Identifica pedras e metais');
+            }
+            if (level >= 10) {
+                abilities.push('Maestria em Armas Grandes: Usa armas grandes como médias');
+            }
+        }
+        
+        // Halfling Aventureiro (Ladrão)
+        else if (/halfling aventureiro|halfling adventurer/i.test(classNameLower)) {
+            if (level >= 1) {
+                abilities.push('Treinamento Racial: Mantém habilidades raciais de halfling');
+            }
+            if (level >= 3) {
+                abilities.push('Sorte Natural: +1 em testes de sorte');
+            }
+            if (level >= 6) {
+                abilities.push('Habilidade com Fundas: +1 de dano com fundas');
+            }
+            if (level >= 10) {
+                abilities.push('Furtividade Aprimorada: +2 em testes de furtividade');
+            }
+        }
+        
+        return abilities;
     }
 
     /**

--- a/scripts/character-generator.js
+++ b/scripts/character-generator.js
@@ -395,6 +395,70 @@ class OldDragon2eCharacterGenerator {
                 'Ler Magias: Decifra inscrições mágicas',
                 'Detectar Magias: Percebe presença mágica'
             ];
+        } else if (/bruxo|warlock|feiticeiro/i.test(classNameLower)) {
+            return [
+                'Armas: Apenas pequenas',
+                'Armaduras: Nenhuma',
+                'Magias Arcanas: Conjura magias arcanas diariamente',
+                'Pacto Mágico: Poderes especiais através de pactos',
+                'Invocação: Conjura magias através de invocações'
+            ];
+        } else if (/necromante|necromancer/i.test(classNameLower)) {
+            return [
+                'Armas: Apenas pequenas',
+                'Armaduras: Nenhuma',
+                'Magias Arcanas: Conjura magias arcanas diariamente',
+                'Necromancia: Especialização em magias de morte',
+                'Comando de Mortos-Vivos: Controla mortos-vivos'
+            ];
+        } else if (/ilusionista|illusionist/i.test(classNameLower)) {
+            return [
+                'Armas: Apenas pequenas',
+                'Armaduras: Nenhuma',
+                'Magias Arcanas: Conjura magias arcanas diariamente',
+                'Ilusões: Especialização em magias de ilusão',
+                'Criação de Ilusões: Cria ilusões convincentes'
+            ];
+        } else if (/bárbaro|barbarian/i.test(classNameLower)) {
+            return [
+                'Armas: Pode usar todas as armas',
+                'Armaduras: Pode usar todas as armaduras',
+                'Fúria: Entra em estado de fúria em combate',
+                'Resistência: Resistência natural a dano',
+                'Ataque Selvagem: Ataques mais poderosos'
+            ];
+        } else if (/paladino|paladin/i.test(classNameLower)) {
+            return [
+                'Armas: Pode usar todas as armas',
+                'Armaduras: Pode usar todas as armaduras',
+                'Magias Divinas: Conjura magias divinas limitadas',
+                'Imunidade a Doenças: Resistência natural',
+                'Cura pelas Mãos: Pode curar ferimentos'
+            ];
+        } else if (/bardo|bard/i.test(classNameLower)) {
+            return [
+                'Armas: Apenas pequenas ou médias',
+                'Armaduras: Apenas leves',
+                'Magias Arcanas: Conjura magias arcanas limitadas',
+                'Inspiração: Motiva aliados com música',
+                'Talentos: Furtividade, Performance, etc.'
+            ];
+        } else if (/ranger/i.test(classNameLower)) {
+            return [
+                'Armas: Pode usar todas as armas',
+                'Armaduras: Apenas leves',
+                'Inimigo Mortal: Bônus contra inimigos específicos',
+                'Rastreamento: Habilidade em seguir trilhas',
+                'Combate Duplo: Usa duas armas simultaneamente'
+            ];
+        } else if (/druida|druid/i.test(classNameLower)) {
+            return [
+                'Armas: Apenas armas naturais e simples',
+                'Armaduras: Apenas couro',
+                'Magias Divinas: Conjura magias divinas diariamente',
+                'Transformação: Transforma-se em animais',
+                'Herbalismo: Conhecimento de plantas medicinais'
+            ];
         }
         
         // Fallback genérico

--- a/scripts/character-generator.js
+++ b/scripts/character-generator.js
@@ -760,7 +760,7 @@ class OldDragon2eCharacterGenerator {
         else if (/bruxo|warlock|feiticeiro/i.test(classNameLower)) {
             if (level >= 1) {
                 abilities.push('Iniciado: Conjura magias 1º círculo, pode usar armas médias e armaduras leves (mesmo metal) sem prejudicar rituais');
-                abilities.push('Metal: Objetos de metal atrapalham canalização (1-2 em 1d6 chance de perder ritual)');
+                abilities.push('Metal: Objetos de metal atrapalham canalização do ritual, impedindo conjuração das magias (1-2 em 1d6 chance de perder ritual sem efeito)');
             }
             if (level >= 3) {
                 abilities.push('Médium: Conjura magias 2º círculo, pode usar armas grandes (mesmo metal) sem prejudicar rituais');

--- a/scripts/character-generator.js
+++ b/scripts/character-generator.js
@@ -711,17 +711,16 @@ class OldDragon2eCharacterGenerator {
         // Assassino (Ladrão)
         else if (/assassino|assassin/i.test(classNameLower)) {
             if (level >= 1) {
-                abilities.push('Veneno: Substitui talento Armadilha - manipula venenos sem se envenenar');
-                abilities.push('Disfarce: Substitui talento Punga - altera aparência para se disfarçar');
+                abilities.push('Ataque Assassino: Após aproximação furtiva, ataque muito fácil com dano x2');
             }
             if (level >= 3) {
-                abilities.push('Ataque Mortal: Ataques fatais se alvo estiver desprevenido');
+                abilities.push('Espreitar: 1 rodada observando = primeiro ataque fácil, 4 rodadas = ataque muito fácil');
             }
             if (level >= 6) {
-                abilities.push('Resistência a Venenos: Bônus em testes de resistência contra venenos');
+                abilities.push('Assassinato: Golpe fatal (1-2 em 1d6), cada DV do alvo ≥ DV do Assassino reduz chance em 1');
             }
             if (level >= 10) {
-                abilities.push('Mestre do Disfarce: Aprimora habilidade de Disfarce');
+                abilities.push('Ataque Mortal: Ataque Assassino evolui para dano x3, Assassinato evolui para 1-3 em 1d6');
             }
         }
         

--- a/scripts/character-generator.js
+++ b/scripts/character-generator.js
@@ -679,16 +679,16 @@ class OldDragon2eCharacterGenerator {
         // Ranger (Ladrão)
         else if (/ranger/i.test(classNameLower)) {
             if (level >= 1) {
-                abilities.push('Inimigo Mortal: Bônus contra inimigos específicos');
+                abilities.push('Inimigo Mortal: Guardião de região dos ermos, escolhe inimigo (Orcs, Goblins, Homens Lagartos, Trolls, Gigantes) - ataques fáceis e -2 em testes de reação');
             }
             if (level >= 3) {
-                abilities.push('Rastreamento: Segue trilhas na natureza');
+                abilities.push('Combativo: Pode usar armas grandes e escudos sem penalidades (limitado a Armaduras Leves)');
             }
             if (level >= 6) {
-                abilities.push('Combate Duplo: Usa duas armas simultaneamente');
+                abilities.push('Previdência: Nos ermos só é surpreendido com 1 em 1d6, acampamentos sempre são seguros');
             }
             if (level >= 10) {
-                abilities.push('Mestre da Floresta: Controle sobre animais selvagens');
+                abilities.push('Companheiro Animal: Criatura dos ermos adota Ranger como aliado (ataques, vigia, mensagens), 1-4 chances em 1d6 de novo companheiro a cada nível se morrer');
             }
         }
         

--- a/scripts/character-generator.js
+++ b/scripts/character-generator.js
@@ -663,16 +663,16 @@ class OldDragon2eCharacterGenerator {
         // Proscrito (Clérigo)
         else if (/proscrito|outcast/i.test(classNameLower)) {
             if (level >= 1) {
-                abilities.push('Cura Natural: Cura 1d6 PV por dia divididos entre alvos desejados');
+                abilities.push('Cura Natural: Cura como curandeiro/médico (2 PV ou 1d4+1 em repouso), pode evitar morte de agonizantes');
             }
             if (level >= 3) {
-                abilities.push('Treinamento em Combate: +1 BA e pode usar qualquer arma ou armadura');
+                abilities.push('Treinamento em Combate: +1 BA em relação a Clérigo padrão, pode usar qualquer arma ou armadura');
             }
             if (level >= 6) {
-                abilities.push('Afetar Mortos-Vivos: Força mortos-vivos a teste de moral (ataques difíceis se falharem)');
+                abilities.push('Afetar Mortos-Vivos: 1x/dia força mortos-vivos a teste de moral (ataques difíceis se falharem)');
             }
             if (level >= 10) {
-                abilities.push('Misticismo: Conjura magias divinas de 1º círculo conforme tabela de Clérigo');
+                abilities.push('Misticismo: Conjura magias divinas de 1º círculo conforme tabela padrão de Clérigo');
             }
         }
         

--- a/scripts/character-generator.js
+++ b/scripts/character-generator.js
@@ -583,16 +583,16 @@ class OldDragon2eCharacterGenerator {
         // Paladino (Guerreiro)
         else if (/paladino|paladin/i.test(classNameLower)) {
             if (level >= 1) {
-                abilities.push('Código de Honra: Deve seguir código de conduta');
+                abilities.push('Imunidade a Doenças: Imune a qualquer doença mundana ou mágica');
             }
             if (level >= 3) {
-                abilities.push('Imunidade a Doenças: Resistência natural a doenças');
+                abilities.push('Cura pelas Mãos: Cura 1 PV por nível do Paladino, 1x/dia (não cura doenças/amputações)');
             }
             if (level >= 6) {
-                abilities.push('Cura pelas Mãos: Pode curar ferimentos 1x/dia');
+                abilities.push('Aura de Proteção: Barreira permanente como magia Proteção contra Alinhamento (vs criaturas caóticas)');
             }
             if (level >= 10) {
-                abilities.push('Afastar Mal: Afasta criaturas malignas');
+                abilities.push('Espada Sagrada: Espada mágica consagrada com +5 dano/ataque contra criaturas caóticas');
             }
         }
         

--- a/scripts/character-generator.js
+++ b/scripts/character-generator.js
@@ -631,16 +631,16 @@ class OldDragon2eCharacterGenerator {
         // Acadêmico (Clérigo)
         else if (/acadêmico|academic/i.test(classNameLower)) {
             if (level >= 1) {
-                abilities.push('Conhecimento Acadêmico: +2 em testes de conhecimento');
+                abilities.push('Conhecimento Acadêmico: Identifica monstros/animais, ataques/defesas, habilidades/fraquezas, hábitos (1-2 em 1d6)');
             }
             if (level >= 3) {
-                abilities.push('Pesquisa: Encontra informações em bibliotecas');
+                abilities.push('Decifrar Linguagens: Decifra idiomas, alfabetos, pictogramas, documentos (Conhecimento Acadêmico evolui para 1-3 em 1d6)');
             }
             if (level >= 6) {
-                abilities.push('Magias Especiais: Acesso a magias únicas');
+                abilities.push('Lendas e Tradições: Identifica lendas, tradições, eventos históricos, curiosidades/perigos de lugares + rumor adicional por modificador de Sabedoria (Conhecimento Acadêmico evolui para 1-4 em 1d6)');
             }
             if (level >= 10) {
-                abilities.push('Sabedoria Suprema: Conhecimento de todas as magias');
+                abilities.push('Identificar Itens: Identifica propósito geral de itens mágicos após 1d4 turnos de observação (1-2 em 1d6, itens caóticos se camuflam)');
             }
         }
         

--- a/scripts/character-generator.js
+++ b/scripts/character-generator.js
@@ -759,16 +759,16 @@ class OldDragon2eCharacterGenerator {
         // Bruxo (Mago)
         else if (/bruxo|warlock|feiticeiro/i.test(classNameLower)) {
             if (level >= 1) {
-                abilities.push('Pacto Mágico: Poderes através de pactos');
+                abilities.push('Iniciado: Conjura magias 1º círculo, pode usar armas médias e armaduras leves (mesmo metal) sem prejudicar rituais');
             }
             if (level >= 3) {
-                abilities.push('Invocação: Conjura magias através de invocações');
+                abilities.push('Médium: Conjura magias 2º círculo, pode usar armas grandes (mesmo metal) sem prejudicar rituais');
             }
             if (level >= 6) {
-                abilities.push('Magias Proibidas: Acesso a magias sombrias');
+                abilities.push('Conjurador: Conjura magias 3º círculo, pode usar armaduras médias (mesmo metal) sem prejudicar rituais');
             }
             if (level >= 10) {
-                abilities.push('Apoteose: Transforma-se em demônio');
+                abilities.push('Entidade: Conjura magias 4º-6º círculos, pode usar todas armaduras/armas (mesmo metal) sem prejudicar rituais');
             }
         }
         

--- a/scripts/character-generator.js
+++ b/scripts/character-generator.js
@@ -727,16 +727,16 @@ class OldDragon2eCharacterGenerator {
         // Ilusionista (Mago)
         else if (/ilusionista|illusionist/i.test(classNameLower)) {
             if (level >= 1) {
-                abilities.push('Especialização em Ilusões: +1 em magias de ilusão');
+                abilities.push('Magias Exclusivas: Ilusão e Som Ilusório no grimório (sem memorizar, 1 uso/dia cada, JP difícil)');
             }
             if (level >= 3) {
-                abilities.push('Criação de Ilusões: Cria ilusões convincentes');
+                abilities.push('Ilusão Melhorada: Magia exclusiva adicionada ao grimório');
             }
             if (level >= 6) {
-                abilities.push('Ilusões Avançadas: Ilusões que causam dano');
+                abilities.push('Miragem: Magia exclusiva adicionada ao grimório');
             }
             if (level >= 10) {
-                abilities.push('Realidade Alternativa: Cria dimensões ilusórias');
+                abilities.push('Ilusão Permanente: Magia exclusiva adicionada ao grimório');
             }
         }
         

--- a/scripts/character-generator.js
+++ b/scripts/character-generator.js
@@ -599,16 +599,16 @@ class OldDragon2eCharacterGenerator {
         // Arqueiro (Guerreiro)
         else if (/arqueiro|archer/i.test(classNameLower)) {
             if (level >= 1) {
-                abilities.push('Especialização em Arco: +1 de dano com arcos');
+                abilities.push('Tiros em Curva: Não são ataques difíceis - cobertura, distância além do arco, alvos em combate corpo a corpo');
             }
             if (level >= 3) {
-                abilities.push('Tiro Preciso: Ignora cobertura parcial');
+                abilities.push('Puxada Aprimorada: Acrescenta modificador de Força nos danos com arcos');
             }
             if (level >= 6) {
-                abilities.push('Tiro Múltiplo: Ataca múltiplos alvos');
+                abilities.push('Truques com Flechas: Grampear, desarmar, efeitos especiais (alvo escolhe consequência ou dano normal)');
             }
             if (level >= 10) {
-                abilities.push('Tiro Mortal: Chance de causar dano crítico');
+                abilities.push('Tiro Rápido: Segundo disparo durante ação de combate');
             }
         }
         

--- a/scripts/character-generator.js
+++ b/scripts/character-generator.js
@@ -567,18 +567,16 @@ class OldDragon2eCharacterGenerator {
         // Bárbaro (Guerreiro)
         else if (/bárbaro|barbarian/i.test(classNameLower)) {
             if (level >= 1) {
-                abilities.push('Aparar: Sacrifica escudo/arma para absorver dano físico');
-                abilities.push('Maestria em Arma: +1 dano em uma arma escolhida');
                 abilities.push('Vigor Bárbaro: +2 PV por nível e +2 na JPC');
             }
             if (level >= 3) {
-                abilities.push('Talentos Selvagens: Escalar, Furtividade, Sobrevivência');
+                abilities.push('Talentos Selvagens: Escalar (1-3 em 1d6), Camuflagem Natural (1-2 em 1d6)');
             }
             if (level >= 6) {
-                abilities.push('Fúria: Aumenta temporariamente força e resistência em combate');
+                abilities.push('Surpresa Selvagem: Surpreende inimigos em ambientes naturais (1-4 em 1d6), só é surpreendido com 1 em 1d6');
             }
             if (level >= 10) {
-                abilities.push('Ataque Extra: Segundo ataque por rodada');
+                abilities.push('Força do Totem: Atinge criaturas que necessitam de arma mágica +1 ou melhor');
             }
         }
         

--- a/scripts/character-generator.js
+++ b/scripts/character-generator.js
@@ -695,15 +695,13 @@ class OldDragon2eCharacterGenerator {
         // Bardo (Ladrão)
         else if (/bardo|bard/i.test(classNameLower)) {
             if (level >= 1) {
-                abilities.push('Ouvir Ruídos: Chance de 1-2 em 1d6 para ouvir ruídos');
-                abilities.push('Talentos de Ladrão: 2 pontos em cada talento + 2 pontos adicionais para distribuir');
-                abilities.push('Influenciar: Modifica Teste de Reação de monstros/NPCs em +1 ou -1');
+                abilities.push('Influenciar: Por música/oratória influencia reações de monstros/NPCs (1-2 em 1d6), +1 ou -1 no Teste de Reação');
             }
             if (level >= 3) {
-                abilities.push('Inspirar: Aliados têm testes de atributos e ataques um nível mais fácil');
+                abilities.push('Inspirar: Atuando por 1+ rodadas, aliados têm testes de atributos/ataques um nível mais fácil');
             }
             if (level >= 6) {
-                abilities.push('Fascinar: Audiência não hostil de até 2 DV a cada 3 níveis fica concentrada');
+                abilities.push('Fascinar: Audiência não hostil até 2 DV a cada 3 níveis fica concentrada no desempenho artístico');
             }
             if (level >= 10) {
                 abilities.push('Usar Pergaminhos: Usa pergaminhos como Mago com metade dos níveis');

--- a/scripts/character-generator.js
+++ b/scripts/character-generator.js
@@ -400,40 +400,40 @@ class OldDragon2eCharacterGenerator {
                 'Armas: Apenas pequenas',
                 'Armaduras: Nenhuma',
                 'Magias Arcanas: Conjura magias arcanas diariamente',
-                'Pacto Mágico: Poderes especiais através de pactos',
-                'Invocação: Conjura magias através de invocações'
+                'Ler Magias: Decifra inscrições mágicas',
+                'Detectar Magias: Percebe presença mágica'
             ];
         } else if (/necromante|necromancer/i.test(classNameLower)) {
             return [
                 'Armas: Apenas pequenas',
                 'Armaduras: Nenhuma',
                 'Magias Arcanas: Conjura magias arcanas diariamente',
-                'Necromancia: Especialização em magias de morte',
-                'Comando de Mortos-Vivos: Controla mortos-vivos'
+                'Ler Magias: Decifra inscrições mágicas',
+                'Detectar Magias: Percebe presença mágica'
             ];
         } else if (/ilusionista|illusionist/i.test(classNameLower)) {
             return [
                 'Armas: Apenas pequenas',
                 'Armaduras: Nenhuma',
                 'Magias Arcanas: Conjura magias arcanas diariamente',
-                'Ilusões: Especialização em magias de ilusão',
-                'Criação de Ilusões: Cria ilusões convincentes'
+                'Ler Magias: Decifra inscrições mágicas',
+                'Detectar Magias: Percebe presença mágica'
             ];
         } else if (/bárbaro|barbarian/i.test(classNameLower)) {
             return [
                 'Armas: Pode usar todas as armas',
                 'Armaduras: Pode usar todas as armaduras',
-                'Fúria: Entra em estado de fúria em combate',
-                'Resistência: Resistência natural a dano',
-                'Ataque Selvagem: Ataques mais poderosos'
+                'Itens Mágicos: Não pode usar cajados, varinhas e pergaminhos mágicos',
+                'Aparar: Sacrifica escudo/arma para absorver dano',
+                'Maestria em Arma: +1 de dano em uma arma escolhida'
             ];
         } else if (/paladino|paladin/i.test(classNameLower)) {
             return [
                 'Armas: Pode usar todas as armas',
                 'Armaduras: Pode usar todas as armaduras',
-                'Magias Divinas: Conjura magias divinas limitadas',
-                'Imunidade a Doenças: Resistência natural',
-                'Cura pelas Mãos: Pode curar ferimentos'
+                'Itens Mágicos: Não pode usar cajados, varinhas e pergaminhos mágicos',
+                'Aparar: Sacrifica escudo/arma para absorver dano',
+                'Maestria em Arma: +1 de dano em uma arma escolhida'
             ];
         } else if (/bardo|bard/i.test(classNameLower)) {
             return [
@@ -445,19 +445,19 @@ class OldDragon2eCharacterGenerator {
             ];
         } else if (/ranger/i.test(classNameLower)) {
             return [
-                'Armas: Pode usar todas as armas',
+                'Armas: Apenas pequenas ou médias',
                 'Armaduras: Apenas leves',
-                'Inimigo Mortal: Bônus contra inimigos específicos',
-                'Rastreamento: Habilidade em seguir trilhas',
-                'Combate Duplo: Usa duas armas simultaneamente'
+                'Ataque Furtivo: Dano x2 em ataques furtivos',
+                'Ouvir Ruídos: Detecta sons (1-2 em 1d6)',
+                'Talentos: Furtividade, Escalar, Arrombar, etc.'
             ];
         } else if (/druida|druid/i.test(classNameLower)) {
             return [
-                'Armas: Apenas armas naturais e simples',
-                'Armaduras: Apenas couro',
+                'Armas: Apenas armas impactantes',
+                'Armaduras: Pode usar todas as armaduras',
                 'Magias Divinas: Conjura magias divinas diariamente',
-                'Transformação: Transforma-se em animais',
-                'Herbalismo: Conhecimento de plantas medicinais'
+                'Afastar Mortos-Vivos: Afasta mortos-vivos 1x/dia',
+                'Cura Milagrosa: Troca magia por Curar Ferimentos'
             ];
         }
         

--- a/scripts/character-generator.js
+++ b/scripts/character-generator.js
@@ -519,32 +519,32 @@ class OldDragon2eCharacterGenerator {
         // Elfo Aventureiro (Mago)
         if (/elfo aventureiro|elf adventurer/i.test(classNameLower)) {
             if (level >= 1) {
-                abilities.push('Treinamento Racial: +1 PV por nível, sem restrições de armas/armaduras, +2 dano com arma racial');
+                abilities.push('Treinamento Racial: Mantém habilidades raciais de elfo, +1 PV por nível, sem restrições de armas/armaduras, +2 dano com arma racial (cimitarra ou arco)');
             }
             if (level >= 3) {
-                abilities.push('Brilho Mágico: Conjura 1 magia de 1º círculo por dia');
+                abilities.push('Brilho Mágico: Conjura 1 magia de 1º círculo por dia como Mago 1º nível (1-3 em 1d6 chance de perder magia com armadura)');
             }
             if (level >= 6) {
-                abilities.push('Esplendor Arcano: Lança magias como Mago 5 níveis abaixo');
+                abilities.push('Esplendor Arcano: Lança magias como Mago 5 níveis abaixo (1-2 em 1d6 chance de perder magia com armadura)');
             }
             if (level >= 10) {
-                abilities.push('Ataque Extra: Segundo ataque com arma racial');
+                abilities.push('Ataque Extra: Segundo ataque com arma racial escolhida (mesma BA, após primeiro ataque)');
             }
         }
         
         // Anão Aventureiro (Guerreiro)
         else if (/anão aventureiro|anao aventureiro|dwarf adventurer/i.test(classNameLower)) {
             if (level >= 1) {
-                abilities.push('Treinamento Racial: Mantém habilidades raciais de anão');
+                abilities.push('Arma Racial: +2 dano com machados ou martelos');
             }
             if (level >= 3) {
-                abilities.push('Resistência a Venenos: +2 em testes contra venenos');
+                abilities.push('Resistência Anã: Bônus em testes de resistência contra venenos e magias');
             }
             if (level >= 6) {
-                abilities.push('Conhecimento de Pedras e Metais: Identifica pedras e metais');
+                abilities.push('Conhecimento de Pedras: Detecta armadilhas e passagens secretas em construções de pedra');
             }
             if (level >= 10) {
-                abilities.push('Maestria em Armas Grandes: Usa armas grandes como médias');
+                abilities.push('Defesa Inabalável: Bônus na CA quando em posição defensiva');
             }
         }
         
@@ -567,16 +567,18 @@ class OldDragon2eCharacterGenerator {
         // Bárbaro (Guerreiro)
         else if (/bárbaro|barbarian/i.test(classNameLower)) {
             if (level >= 1) {
-                abilities.push('Fúria: Entra em estado de fúria em combate (+2 Força, -1 CA)');
+                abilities.push('Aparar: Sacrifica escudo/arma para absorver dano físico');
+                abilities.push('Maestria em Arma: +1 dano em uma arma escolhida');
+                abilities.push('Vigor Bárbaro: +2 PV por nível e +2 na JPC');
             }
             if (level >= 3) {
-                abilities.push('Resistência: Resistência natural a dano físico');
+                abilities.push('Talentos Selvagens: Escalar, Furtividade, Sobrevivência');
             }
             if (level >= 6) {
-                abilities.push('Ataque Selvagem: Ataques mais poderosos em fúria');
+                abilities.push('Fúria: Aumenta temporariamente força e resistência em combate');
             }
             if (level >= 10) {
-                abilities.push('Fúria Indomável: Imunidade a efeitos mentais em fúria');
+                abilities.push('Ataque Extra: Segundo ataque por rodada');
             }
         }
         
@@ -663,16 +665,16 @@ class OldDragon2eCharacterGenerator {
         // Proscrito (Clérigo)
         else if (/proscrito|outcast/i.test(classNameLower)) {
             if (level >= 1) {
-                abilities.push('Magias Proibidas: Acesso a magias sombrias');
+                abilities.push('Cura Natural: Cura 1d6 PV por dia divididos entre alvos desejados');
             }
             if (level >= 3) {
-                abilities.push('Corrupção: Pode corromper outros');
+                abilities.push('Treinamento em Combate: +1 BA e pode usar qualquer arma ou armadura');
             }
             if (level >= 6) {
-                abilities.push('Necromancia: Cria mortos-vivos');
+                abilities.push('Afetar Mortos-Vivos: Força mortos-vivos a teste de moral (ataques difíceis se falharem)');
             }
             if (level >= 10) {
-                abilities.push('Apoteose: Transforma-se em lich');
+                abilities.push('Misticismo: Conjura magias divinas de 1º círculo conforme tabela de Clérigo');
             }
         }
         
@@ -695,32 +697,35 @@ class OldDragon2eCharacterGenerator {
         // Bardo (Ladrão)
         else if (/bardo|bard/i.test(classNameLower)) {
             if (level >= 1) {
-                abilities.push('Inspiração: Motiva aliados com música');
+                abilities.push('Ouvir Ruídos: Chance de 1-2 em 1d6 para ouvir ruídos');
+                abilities.push('Talentos de Ladrão: 2 pontos em cada talento + 2 pontos adicionais para distribuir');
+                abilities.push('Influenciar: Modifica Teste de Reação de monstros/NPCs em +1 ou -1');
             }
             if (level >= 3) {
-                abilities.push('Magias Menores: Conjura magias arcanas limitadas');
+                abilities.push('Inspirar: Aliados têm testes de atributos e ataques um nível mais fácil');
             }
             if (level >= 6) {
-                abilities.push('Performance: Encanta audiências');
+                abilities.push('Fascinar: Audiência não hostil de até 2 DV a cada 3 níveis fica concentrada');
             }
             if (level >= 10) {
-                abilities.push('Magia Suprema: Conjura magias poderosas');
+                abilities.push('Usar Pergaminhos: Usa pergaminhos como Mago com metade dos níveis');
             }
         }
         
         // Assassino (Ladrão)
         else if (/assassino|assassin/i.test(classNameLower)) {
             if (level >= 1) {
-                abilities.push('Ataque Furtivo Aprimorado: Dano x3 em ataques furtivos');
+                abilities.push('Veneno: Substitui talento Armadilha - manipula venenos sem se envenenar');
+                abilities.push('Disfarce: Substitui talento Punga - altera aparência para se disfarçar');
             }
             if (level >= 3) {
-                abilities.push('Veneno: Conhecimento de venenos');
+                abilities.push('Ataque Mortal: Ataques fatais se alvo estiver desprevenido');
             }
             if (level >= 6) {
-                abilities.push('Disfarce: Assume identidades falsas');
+                abilities.push('Resistência a Venenos: Bônus em testes de resistência contra venenos');
             }
             if (level >= 10) {
-                abilities.push('Morte Instantânea: Chance de matar instantaneamente');
+                abilities.push('Mestre do Disfarce: Aprimora habilidade de Disfarce');
             }
         }
         

--- a/scripts/character-generator.js
+++ b/scripts/character-generator.js
@@ -615,16 +615,16 @@ class OldDragon2eCharacterGenerator {
         // Druida (Clérigo)
         else if (/druida|druid/i.test(classNameLower)) {
             if (level >= 1) {
-                abilities.push('Comunhão com Natureza: Compreende animais');
+                abilities.push('Herbalismo: Identifica plantas, animais e reconhece água pura e segura');
             }
             if (level >= 3) {
-                abilities.push('Transformação: Transforma-se em animais');
+                abilities.push('Previdência: Acampamentos nos ermos sempre são do tipo seguro');
             }
             if (level >= 6) {
-                abilities.push('Herbalismo: Conhecimento de plantas medicinais');
+                abilities.push('Transformação: Assume forma de animal pequeno não-mágico até 6 DV, 3x/dia');
             }
             if (level >= 10) {
-                abilities.push('Forma Elemental: Transforma-se em elemento');
+                abilities.push('Transformação Melhorada: Assume forma de animal não-mágico qualquer tamanho até 10 DV, 3x/dia');
             }
         }
         

--- a/scripts/character-generator.js
+++ b/scripts/character-generator.js
@@ -564,6 +564,214 @@ class OldDragon2eCharacterGenerator {
             }
         }
         
+        // Bárbaro (Guerreiro)
+        else if (/bárbaro|barbarian/i.test(classNameLower)) {
+            if (level >= 1) {
+                abilities.push('Fúria: Entra em estado de fúria em combate (+2 Força, -1 CA)');
+            }
+            if (level >= 3) {
+                abilities.push('Resistência: Resistência natural a dano físico');
+            }
+            if (level >= 6) {
+                abilities.push('Ataque Selvagem: Ataques mais poderosos em fúria');
+            }
+            if (level >= 10) {
+                abilities.push('Fúria Indomável: Imunidade a efeitos mentais em fúria');
+            }
+        }
+        
+        // Paladino (Guerreiro)
+        else if (/paladino|paladin/i.test(classNameLower)) {
+            if (level >= 1) {
+                abilities.push('Código de Honra: Deve seguir código de conduta');
+            }
+            if (level >= 3) {
+                abilities.push('Imunidade a Doenças: Resistência natural a doenças');
+            }
+            if (level >= 6) {
+                abilities.push('Cura pelas Mãos: Pode curar ferimentos 1x/dia');
+            }
+            if (level >= 10) {
+                abilities.push('Afastar Mal: Afasta criaturas malignas');
+            }
+        }
+        
+        // Arqueiro (Guerreiro)
+        else if (/arqueiro|archer/i.test(classNameLower)) {
+            if (level >= 1) {
+                abilities.push('Especialização em Arco: +1 de dano com arcos');
+            }
+            if (level >= 3) {
+                abilities.push('Tiro Preciso: Ignora cobertura parcial');
+            }
+            if (level >= 6) {
+                abilities.push('Tiro Múltiplo: Ataca múltiplos alvos');
+            }
+            if (level >= 10) {
+                abilities.push('Tiro Mortal: Chance de causar dano crítico');
+            }
+        }
+        
+        // Druida (Clérigo)
+        else if (/druida|druid/i.test(classNameLower)) {
+            if (level >= 1) {
+                abilities.push('Comunhão com Natureza: Compreende animais');
+            }
+            if (level >= 3) {
+                abilities.push('Transformação: Transforma-se em animais');
+            }
+            if (level >= 6) {
+                abilities.push('Herbalismo: Conhecimento de plantas medicinais');
+            }
+            if (level >= 10) {
+                abilities.push('Forma Elemental: Transforma-se em elemento');
+            }
+        }
+        
+        // Acadêmico (Clérigo)
+        else if (/acadêmico|academic/i.test(classNameLower)) {
+            if (level >= 1) {
+                abilities.push('Conhecimento Acadêmico: +2 em testes de conhecimento');
+            }
+            if (level >= 3) {
+                abilities.push('Pesquisa: Encontra informações em bibliotecas');
+            }
+            if (level >= 6) {
+                abilities.push('Magias Especiais: Acesso a magias únicas');
+            }
+            if (level >= 10) {
+                abilities.push('Sabedoria Suprema: Conhecimento de todas as magias');
+            }
+        }
+        
+        // Xamã (Clérigo)
+        else if (/xamã|shaman/i.test(classNameLower)) {
+            if (level >= 1) {
+                abilities.push('Comunhão Espiritual: Contato com espíritos');
+            }
+            if (level >= 3) {
+                abilities.push('Visões: Recebe visões proféticas');
+            }
+            if (level >= 6) {
+                abilities.push('Possessão: Espíritos podem possuir aliados');
+            }
+            if (level >= 10) {
+                abilities.push('Ascensão: Transforma-se em espírito');
+            }
+        }
+        
+        // Proscrito (Clérigo)
+        else if (/proscrito|outcast/i.test(classNameLower)) {
+            if (level >= 1) {
+                abilities.push('Magias Proibidas: Acesso a magias sombrias');
+            }
+            if (level >= 3) {
+                abilities.push('Corrupção: Pode corromper outros');
+            }
+            if (level >= 6) {
+                abilities.push('Necromancia: Cria mortos-vivos');
+            }
+            if (level >= 10) {
+                abilities.push('Apoteose: Transforma-se em lich');
+            }
+        }
+        
+        // Ranger (Ladrão)
+        else if (/ranger/i.test(classNameLower)) {
+            if (level >= 1) {
+                abilities.push('Inimigo Mortal: Bônus contra inimigos específicos');
+            }
+            if (level >= 3) {
+                abilities.push('Rastreamento: Segue trilhas na natureza');
+            }
+            if (level >= 6) {
+                abilities.push('Combate Duplo: Usa duas armas simultaneamente');
+            }
+            if (level >= 10) {
+                abilities.push('Mestre da Floresta: Controle sobre animais selvagens');
+            }
+        }
+        
+        // Bardo (Ladrão)
+        else if (/bardo|bard/i.test(classNameLower)) {
+            if (level >= 1) {
+                abilities.push('Inspiração: Motiva aliados com música');
+            }
+            if (level >= 3) {
+                abilities.push('Magias Menores: Conjura magias arcanas limitadas');
+            }
+            if (level >= 6) {
+                abilities.push('Performance: Encanta audiências');
+            }
+            if (level >= 10) {
+                abilities.push('Magia Suprema: Conjura magias poderosas');
+            }
+        }
+        
+        // Assassino (Ladrão)
+        else if (/assassino|assassin/i.test(classNameLower)) {
+            if (level >= 1) {
+                abilities.push('Ataque Furtivo Aprimorado: Dano x3 em ataques furtivos');
+            }
+            if (level >= 3) {
+                abilities.push('Veneno: Conhecimento de venenos');
+            }
+            if (level >= 6) {
+                abilities.push('Disfarce: Assume identidades falsas');
+            }
+            if (level >= 10) {
+                abilities.push('Morte Instantânea: Chance de matar instantaneamente');
+            }
+        }
+        
+        // Ilusionista (Mago)
+        else if (/ilusionista|illusionist/i.test(classNameLower)) {
+            if (level >= 1) {
+                abilities.push('Especialização em Ilusões: +1 em magias de ilusão');
+            }
+            if (level >= 3) {
+                abilities.push('Criação de Ilusões: Cria ilusões convincentes');
+            }
+            if (level >= 6) {
+                abilities.push('Ilusões Avançadas: Ilusões que causam dano');
+            }
+            if (level >= 10) {
+                abilities.push('Realidade Alternativa: Cria dimensões ilusórias');
+            }
+        }
+        
+        // Necromante (Mago)
+        else if (/necromante|necromancer/i.test(classNameLower)) {
+            if (level >= 1) {
+                abilities.push('Especialização em Necromancia: +1 em magias de morte');
+            }
+            if (level >= 3) {
+                abilities.push('Comando de Mortos-Vivos: Controla mortos-vivos');
+            }
+            if (level >= 6) {
+                abilities.push('Drenar Vida: Absorve vida de inimigos');
+            }
+            if (level >= 10) {
+                abilities.push('Imortalidade: Transforma-se em lich');
+            }
+        }
+        
+        // Bruxo (Mago)
+        else if (/bruxo|warlock|feiticeiro/i.test(classNameLower)) {
+            if (level >= 1) {
+                abilities.push('Pacto Mágico: Poderes através de pactos');
+            }
+            if (level >= 3) {
+                abilities.push('Invocação: Conjura magias através de invocações');
+            }
+            if (level >= 6) {
+                abilities.push('Magias Proibidas: Acesso a magias sombrias');
+            }
+            if (level >= 10) {
+                abilities.push('Apoteose: Transforma-se em demônio');
+            }
+        }
+        
         return abilities;
     }
 

--- a/scripts/character-generator.js
+++ b/scripts/character-generator.js
@@ -435,6 +435,14 @@ class OldDragon2eCharacterGenerator {
                 'Aparar: Sacrifica escudo/arma para absorver dano',
                 'Maestria em Arma: +1 de dano em uma arma escolhida'
             ];
+        } else if (/arqueiro|archer/i.test(classNameLower)) {
+            return [
+                'Armas: Pode usar todas as armas',
+                'Armaduras: Pode usar todas as armaduras',
+                'Itens Mágicos: Não pode usar cajados, varinhas e pergaminhos mágicos',
+                'Aparar: Sacrifica escudo/arma para absorver dano',
+                'Maestria em Arma: +1 de dano em uma arma escolhida'
+            ];
         } else if (/bardo|bard/i.test(classNameLower)) {
             return [
                 'Armas: Apenas pequenas ou médias. Armas grandes geram ataques difíceis',
@@ -451,7 +459,39 @@ class OldDragon2eCharacterGenerator {
                 'Ouvir Ruídos: Detecta sons (1-2 em 1d6)',
                 'Talentos: Furtividade, Escalar, Arrombar, etc.'
             ];
+        } else if (/assassino|assassin/i.test(classNameLower)) {
+            return [
+                'Armas: Apenas pequenas ou médias',
+                'Armaduras: Apenas leves',
+                'Ataque Furtivo: Dano x2 em ataques furtivos',
+                'Ouvir Ruídos: Detecta sons (1-2 em 1d6)',
+                'Talentos: Furtividade, Escalar, Arrombar, etc.'
+            ];
         } else if (/druida|druid/i.test(classNameLower)) {
+            return [
+                'Armas: Apenas armas impactantes',
+                'Armaduras: Pode usar todas as armaduras',
+                'Magias Divinas: Conjura magias divinas diariamente',
+                'Afastar Mortos-Vivos: Afasta mortos-vivos 1x/dia',
+                'Cura Milagrosa: Troca magia por Curar Ferimentos'
+            ];
+        } else if (/acadêmico|academic/i.test(classNameLower)) {
+            return [
+                'Armas: Apenas armas impactantes',
+                'Armaduras: Pode usar todas as armaduras',
+                'Magias Divinas: Conjura magias divinas diariamente',
+                'Afastar Mortos-Vivos: Afasta mortos-vivos 1x/dia',
+                'Cura Milagrosa: Troca magia por Curar Ferimentos'
+            ];
+        } else if (/xamã|shaman/i.test(classNameLower)) {
+            return [
+                'Armas: Apenas armas impactantes',
+                'Armaduras: Pode usar todas as armaduras',
+                'Magias Divinas: Conjura magias divinas diariamente',
+                'Afastar Mortos-Vivos: Afasta mortos-vivos 1x/dia',
+                'Cura Milagrosa: Troca magia por Curar Ferimentos'
+            ];
+        } else if (/proscrito|outcast/i.test(classNameLower)) {
             return [
                 'Armas: Apenas armas impactantes',
                 'Armaduras: Pode usar todas as armaduras',

--- a/scripts/character-generator.js
+++ b/scripts/character-generator.js
@@ -551,16 +551,16 @@ class OldDragon2eCharacterGenerator {
         // Halfling Aventureiro (Ladrão)
         else if (/halfling aventureiro|halfling adventurer/i.test(classNameLower)) {
             if (level >= 1) {
-                abilities.push('Treinamento Racial: Mantém habilidades raciais de halfling');
+                abilities.push('Arma Racial: Mantém habilidades raciais de halfling, +2 dano com arma de arremesso escolhida');
             }
             if (level >= 3) {
-                abilities.push('Sorte Natural: +1 em testes de sorte');
+                abilities.push('Valente: Imune a efeitos de medo/terror/horror, testes de atributo/JP/ataque se tornam fáceis quando amedrontado');
             }
             if (level >= 6) {
-                abilities.push('Habilidade com Fundas: +1 de dano com fundas');
+                abilities.push('No Alvo: Ataques à distância com arma racial são considerados muito fáceis');
             }
             if (level >= 10) {
-                abilities.push('Furtividade Aprimorada: +2 em testes de furtividade');
+                abilities.push('Arremesso Extra: Segundo arremesso por ataque com arma racial (mesma BA, após primeiro ataque)');
             }
         }
         

--- a/scripts/character-generator.js
+++ b/scripts/character-generator.js
@@ -535,16 +535,16 @@ class OldDragon2eCharacterGenerator {
         // Anão Aventureiro (Guerreiro)
         else if (/anão aventureiro|anao aventureiro|dwarf adventurer/i.test(classNameLower)) {
             if (level >= 1) {
-                abilities.push('Arma Racial: +2 dano com machados ou martelos');
+                abilities.push('Arma Racial: Mantém habilidades raciais de anão, +2 dano com machado ou martelo escolhido');
             }
             if (level >= 3) {
-                abilities.push('Resistência Anã: Bônus em testes de resistência contra venenos e magias');
+                abilities.push('Duro na Queda: Joga PV com 1d12 em vez de 1d10 (ou escolhe valor médio 6)');
             }
             if (level >= 6) {
-                abilities.push('Conhecimento de Pedras: Detecta armadilhas e passagens secretas em construções de pedra');
+                abilities.push('Bastião Racial: Ataques de Orcs, Ogros e Hobgoblins são considerados difíceis');
             }
             if (level >= 10) {
-                abilities.push('Defesa Inabalável: Bônus na CA quando em posição defensiva');
+                abilities.push('Ataque Extra: Segundo ataque com arma racial escolhida (mesma BA, após primeiro ataque)');
             }
         }
         

--- a/scripts/character-generator.js
+++ b/scripts/character-generator.js
@@ -437,11 +437,11 @@ class OldDragon2eCharacterGenerator {
             ];
         } else if (/bardo|bard/i.test(classNameLower)) {
             return [
-                'Armas: Apenas pequenas ou médias',
-                'Armaduras: Apenas leves',
-                'Magias Arcanas: Conjura magias arcanas limitadas',
-                'Inspiração: Motiva aliados com música',
-                'Talentos: Furtividade, Performance, etc.'
+                'Armas: Apenas pequenas ou médias. Armas grandes geram ataques difíceis',
+                'Armaduras: Apenas leves. Escudos e armaduras médias/pesadas impedem habilidades',
+                'Itens Mágicos: Podem usar todos os pergaminhos com metade dos níveis',
+                'Inspiração: Motiva aliados com música e performance',
+                'Talentos: Furtividade, Performance, Escalar, Arrombar, etc.'
             ];
         } else if (/ranger/i.test(classNameLower)) {
             return [

--- a/scripts/character-generator.js
+++ b/scripts/character-generator.js
@@ -743,16 +743,16 @@ class OldDragon2eCharacterGenerator {
         // Necromante (Mago)
         else if (/necromante|necromancer/i.test(classNameLower)) {
             if (level >= 1) {
-                abilities.push('Magias Exclusivas: Acesso a Aterrorizar e Toque Sombrio');
+                abilities.push('Magias Exclusivas: Toque Sombrio e Aterrorizar no grimório (sem memorizar, 1 uso/dia cada, JP difícil)');
             }
             if (level >= 3) {
-                abilities.push('Comando de Mortos-Vivos: Controla criaturas mortas-vivas');
+                abilities.push('Criar Mortos-Vivos: Magia exclusiva adicionada ao grimório');
             }
             if (level >= 6) {
-                abilities.push('Criar Mortos-Vivos: Anima cadáveres como servos');
+                abilities.push('Drenar Vida: Magia exclusiva adicionada ao grimório');
             }
             if (level >= 10) {
-                abilities.push('Drenar Vida: Absorve energia vital de inimigos');
+                abilities.push('Magia da Morte: Magia exclusiva adicionada ao grimório');
             }
         }
         

--- a/scripts/character-generator.js
+++ b/scripts/character-generator.js
@@ -743,16 +743,16 @@ class OldDragon2eCharacterGenerator {
         // Necromante (Mago)
         else if (/necromante|necromancer/i.test(classNameLower)) {
             if (level >= 1) {
-                abilities.push('Especialização em Necromancia: +1 em magias de morte');
+                abilities.push('Magias Exclusivas: Acesso a Aterrorizar e Toque Sombrio');
             }
             if (level >= 3) {
-                abilities.push('Comando de Mortos-Vivos: Controla mortos-vivos');
+                abilities.push('Comando de Mortos-Vivos: Controla criaturas mortas-vivas');
             }
             if (level >= 6) {
-                abilities.push('Drenar Vida: Absorve vida de inimigos');
+                abilities.push('Criar Mortos-Vivos: Anima cadáveres como servos');
             }
             if (level >= 10) {
-                abilities.push('Imortalidade: Transforma-se em lich');
+                abilities.push('Drenar Vida: Absorve energia vital de inimigos');
             }
         }
         


### PR DESCRIPTION
Implementa extração de habilidades diretamente do SRD oficial do Old Dragon 2e, eliminando strings hardcoded e garantindo dados oficiais. Corrige bugs de seleção dupla de classe e estrutura de languages.