### PR TITLE
fix: Corrige problemas de rolagem e carregamento de descrições no reroll de equipamentos

### DIFF
--- a/scripts/character-generator.js
+++ b/scripts/character-generator.js
@@ -1797,29 +1797,45 @@ class OldDragon2eCharacterGenerator {
      */
     async updateEquipmentInModal(html, character) {
         const equipmentItems = html.find('.equipment-items');
+        const existingItems = equipmentItems.find('.equipment-item');
         
-        // Preserva a posição da rolagem antes da atualização
-        const scrollContainer = html.find('.old-dragon-generator-modal').closest('.window-app');
-        const scrollTop = scrollContainer.scrollTop();
-        
-        // Limpa o conteúdo atual
-        equipmentItems.empty();
-        
-        // Adiciona os novos itens de equipamento
-        character.equipment.forEach(item => {
-            const itemHtml = `
-                <div class="equipment-item">
-                    <div class="equipment-name">${item}</div>
-                    <div class="equipment-description">Carregando descrição...</div>
-                </div>
-            `;
-            equipmentItems.append(itemHtml);
-        });
-        
-        // Restaura a posição da rolagem após um pequeno delay
-        setTimeout(() => {
-            scrollContainer.scrollTop(scrollTop);
-        }, 10);
+        // Se há itens existentes, atualiza apenas os nomes
+        if (existingItems.length > 0) {
+            character.equipment.forEach((item, index) => {
+                if (existingItems.eq(index).length > 0) {
+                    // Atualiza nome do item existente
+                    existingItems.eq(index).find('.equipment-name').text(item);
+                    existingItems.eq(index).find('.equipment-description').text('Carregando descrição...');
+                } else {
+                    // Adiciona novo item se não existir
+                    const itemHtml = `
+                        <div class="equipment-item">
+                            <div class="equipment-name">${item}</div>
+                            <div class="equipment-description">Carregando descrição...</div>
+                        </div>
+                    `;
+                    equipmentItems.append(itemHtml);
+                }
+            });
+            
+            // Remove itens extras se o novo equipamento tem menos itens
+            if (existingItems.length > character.equipment.length) {
+                for (let i = character.equipment.length; i < existingItems.length; i++) {
+                    existingItems.eq(i).remove();
+                }
+            }
+        } else {
+            // Se não há itens existentes, cria todos
+            character.equipment.forEach(item => {
+                const itemHtml = `
+                    <div class="equipment-item">
+                        <div class="equipment-name">${item}</div>
+                        <div class="equipment-description">Carregando descrição...</div>
+                    </div>
+                `;
+                equipmentItems.append(itemHtml);
+            });
+        }
         
         // Carrega descrições de forma assíncrona
         await this.loadEquipmentDescriptions(character.equipment, equipmentItems);

--- a/scripts/character-generator.js
+++ b/scripts/character-generator.js
@@ -1797,6 +1797,12 @@ class OldDragon2eCharacterGenerator {
      */
     async updateEquipmentInModal(html, character) {
         const equipmentItems = html.find('.equipment-items');
+        
+        // Preserva a posição da rolagem antes da atualização
+        const scrollContainer = html.find('.old-dragon-generator-modal').closest('.window-app');
+        const scrollTop = scrollContainer.scrollTop();
+        
+        // Limpa o conteúdo atual
         equipmentItems.empty();
         
         // Adiciona os novos itens de equipamento
@@ -1809,6 +1815,11 @@ class OldDragon2eCharacterGenerator {
             `;
             equipmentItems.append(itemHtml);
         });
+        
+        // Restaura a posição da rolagem após um pequeno delay
+        setTimeout(() => {
+            scrollContainer.scrollTop(scrollTop);
+        }, 10);
         
         // Carrega descrições de forma assíncrona
         await this.loadEquipmentDescriptions(character.equipment, equipmentItems);

--- a/styles/character-generator.css
+++ b/styles/character-generator.css
@@ -452,6 +452,44 @@
     transform: none;
 }
 
+/* Botão de re-rolar equipamento */
+.old-dragon-generator-modal .btn-reroll-equipment {
+    cursor: pointer;
+    transition: all 0.3s ease;
+    padding: 2px 4px;
+    border-radius: 4px;
+    margin-right: 6px;
+    display: inline-block;
+    position: relative;
+    animation: gentle-glow-red 2s ease-in-out infinite;
+    color: #8B0000;
+}
+
+.old-dragon-generator-modal .btn-reroll-equipment:hover {
+    color: #228B22;
+    background: rgba(34, 139, 34, 0.15);
+    transform: scale(1.15);
+    box-shadow: 0 2px 8px rgba(34, 139, 34, 0.3);
+    animation: gentle-glow-green 1.5s ease-in-out infinite;
+}
+
+.old-dragon-generator-modal .btn-reroll-equipment:active {
+    transform: scale(0.95);
+    color: #006400;
+}
+
+.old-dragon-generator-modal .btn-reroll-equipment:disabled {
+    cursor: not-allowed;
+    opacity: 0.5;
+    transform: none;
+}
+
+.old-dragon-generator-modal .btn-reroll-equipment:disabled:hover {
+    color: #8B0000;
+    background: none;
+    transform: none;
+}
+
 .old-dragon-generator-modal .attribute-item {
     background: linear-gradient(135deg, #ffffff, #f5f5f0);
     padding: 8px 6px;
@@ -534,6 +572,9 @@
     margin-bottom: 15px;
     font-size: 1.4em; /* Fonte ainda maior */
     font-weight: bold;
+    display: flex;
+    align-items: center;
+    gap: 8px;
 }
 
 .old-dragon-generator-modal .equipment-items {


### PR DESCRIPTION
Resolve dois problemas importantes:

1. Barra de rolagem que subia repentinamente ao rerolar equipamentos
2. Descrições que ficavam 'carregando descrição'

Implementa preservação robusta da rolagem e nova função de carregamento sem limpar o DOM.