### PR TITLE
Fix: Corrige cálculo de PV para usar valor máximo do dado no primeiro nível (v2.1.2)

### DIFF
--- a/module.json
+++ b/module.json
@@ -2,7 +2,7 @@
   "id": "old-dragon-2e-gerador-de-personagens",
   "title": "Old Dragon 2e - Gerador de Personagens",
   "description": "Um módulo para gerar personagens automaticamente para o sistema Old Dragon 2e. Permite criar personagens com atributos aleatórios, classes, raças e equipamentos seguindo as regras do sistema. Inclui arquitetura modular com classes especializadas para melhor organização e manutenibilidade.",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "compatibility": {
     "minimum": "13",
     "verified": "13",

--- a/scripts/character-generator.js
+++ b/scripts/character-generator.js
@@ -1002,12 +1002,10 @@ class OldDragon2eCharacterGenerator {
                     bad: characterData.baseAttack.bad,
                     
                     // Vida e Movimento
-                    pv: characterData.hitPoints,
-                    pv_max: characterData.hitPoints,
-                    hp: characterData.hitPoints,
-                    hp_max: characterData.hitPoints,
-                    hitPoints: characterData.hitPoints,
-                    hitPointsMax: characterData.hitPoints,
+                    hp: {
+                        value: characterData.hitPoints,
+                        max: characterData.hitPoints
+                    },
                     movimento: characterData.movement,
                     
                     // Informações básicas
@@ -1059,16 +1057,12 @@ class OldDragon2eCharacterGenerator {
             
             // Força a atualização dos PV após a criação
             await actor.update({
-                'system.pv': characterData.hitPoints,
-                'system.pv_max': characterData.hitPoints,
-                'system.hp': characterData.hitPoints,
-                'system.hp_max': characterData.hitPoints,
-                'system.hitPoints': characterData.hitPoints,
-                'system.hitPointsMax': characterData.hitPoints
+                'system.hp.value': characterData.hitPoints,
+                'system.hp.max': characterData.hitPoints
             });
             
             // Debug: verifica se a atualização funcionou
-            console.log('Debug - PV após atualização:', actor.system.pv, actor.system.hp, actor.system.hitPoints);
+            console.log('Debug - PV após atualização:', actor.system.hp.value, actor.system.hp.max);
             
             // Importa Raça e Classe do SRD como Itens do Ator
             try {

--- a/scripts/character-generator.js
+++ b/scripts/character-generator.js
@@ -278,14 +278,6 @@ class OldDragon2eCharacterGenerator {
 
             const allSpells = await spellPack.getDocuments();
             
-            // Debug: mostra algumas magias para entender o formato
-            console.log('Exemplos de magias disponíveis:', allSpells.slice(0, 3).map(s => ({ 
-                name: s.name, 
-                circle: s.system?.circle, 
-                system: s.system,
-                type: s.type,
-                systemKeys: Object.keys(s.system || {})
-            })));
             
             const firstCircleSpells = allSpells.filter(spell => {
                 // No Old Dragon 2e, as magias de 1º círculo têm valor "1" nos campos de escola
@@ -956,13 +948,6 @@ class OldDragon2eCharacterGenerator {
             else if (raceName.includes('anão') || raceName.includes('anao')) jpRaceBonus = 'jpc';
             else if (raceName.includes('halfling')) jpRaceBonus = 'jps';
 
-            // Debug: verifica os PV antes de criar o personagem
-            console.log('Debug PV - characterData.hitPoints:', characterData.hitPoints);
-            console.log('Debug PV - characterData:', characterData);
-            
-            // Debug: verifica a estrutura do sistema Old Dragon 2e
-            console.log('Debug - Sistema Old Dragon 2e:', game.system);
-            console.log('Debug - Template de personagem:', game.system.template?.Actor?.character);
             
             // Cria o personagem com estrutura do sistema Old Dragon 2e
             const actorData = {
@@ -1050,19 +1035,6 @@ class OldDragon2eCharacterGenerator {
             };
 
             const actor = await Actor.create(actorData);
-            
-            // Debug: verifica a estrutura do personagem criado
-            console.log('Debug - Personagem criado:', actor);
-            console.log('Debug - System do personagem:', actor.system);
-            
-            // Força a atualização dos PV após a criação
-            await actor.update({
-                'system.hp.value': characterData.hitPoints,
-                'system.hp.max': characterData.hitPoints
-            });
-            
-            // Debug: verifica se a atualização funcionou
-            console.log('Debug - PV após atualização:', actor.system.hp.value, actor.system.hp.max);
             
             // Importa Raça e Classe do SRD como Itens do Ator
             try {
@@ -1487,8 +1459,6 @@ class OldDragon2eCharacterGenerator {
             return false;
         });
         
-        // Debug: mostra as classes filtradas
-        console.log(`Classes disponíveis para raça ${raceId} (${raceName}):`, filteredClasses.map(c => c.name));
         
         return filteredClasses;
     }
@@ -1539,7 +1509,6 @@ class OldDragon2eCharacterGenerator {
         // Se apenas a classe foi alterada, recalcula valores dependentes da classe
         else if (selectedClass && !selectedRace) {
             const archetype = this.mapClassToArchetype(selectedClass.name);
-            console.log('Atualizando apenas classe:', selectedClass.name, '-> archetype:', archetype);
             
             character.hitPoints = this.calculateHitPoints(archetype, character.attributes.constitution);
             character.armorClass = this.calculateArmorClass(character.attributes.dexterity, character.equipment);
@@ -2082,7 +2051,6 @@ class OldDragon2eCharacterGenerator {
             if (bacElement.length > 0) {
                 const spanElement = bacElement.find('span');
                 if (spanElement.length > 0) {
-                    console.log('Atualizando BAC via índice 6');
                     spanElement.html(`${character.baseAttack.bac} <strong>BAD:</strong> ${character.baseAttack.bad}`);
                     bacUpdated = true;
                 }
@@ -2091,14 +2059,12 @@ class OldDragon2eCharacterGenerator {
         
         // Se ainda não funcionou, força a atualização usando todos os elementos
         if (!bacUpdated) {
-            console.log('Forçando atualização de BAC');
             infoItems.each((index, element) => {
                 const $element = $(element);
                 if ($element.text().includes('BAC:')) {
                     const span = $element.find('span');
                     if (span.length > 0) {
                         span.html(`${character.baseAttack.bac} <strong>BAD:</strong> ${character.baseAttack.bad}`);
-                        console.log('BAC atualizado via força bruta');
                         bacUpdated = true;
                     }
                 }
@@ -2154,10 +2120,6 @@ class OldDragon2eCharacterGenerator {
         const allRaces = await this.loadAllRaces();
         const allClasses = await this.loadAllClasses();
         
-        // Debug: mostra todas as classes disponíveis
-        console.log('Todas as classes disponíveis no SRD:', allClasses.map(c => c.name));
-        console.log('Classes que contêm "aventureiro":', allClasses.filter(c => c.name.toLowerCase().includes('aventureiro')).map(c => c.name));
-        console.log('Classes que contêm "adventurer":', allClasses.filter(c => c.name.toLowerCase().includes('adventurer')).map(c => c.name));
         
         // Seleciona raça e classe aleatórias iniciais
         const selectedRace = allRaces.length > 0 ? allRaces[Math.floor(Math.random() * allRaces.length)] : null;

--- a/scripts/character-generator.js
+++ b/scripts/character-generator.js
@@ -606,7 +606,8 @@ class OldDragon2eCharacterGenerator {
         const hitDie = { fighter: 10, cleric: 8, thief: 6, mage: 4 };
         const die = hitDie[archetype] || 6;
         const modifier = this.calculateModifiers({ constitution }).constitution;
-        return Math.max(1, this.rollDie(die) + modifier);
+        // Para o primeiro nível, usa o valor máximo do dado + modificador
+        return Math.max(1, die + modifier);
     }
 
     /**

--- a/scripts/character-generator.js
+++ b/scripts/character-generator.js
@@ -1002,6 +1002,8 @@ class OldDragon2eCharacterGenerator {
                     pv_max: characterData.hitPoints,
                     hp: characterData.hitPoints,
                     hp_max: characterData.hitPoints,
+                    hitPoints: characterData.hitPoints,
+                    hitPointsMax: characterData.hitPoints,
                     movimento: characterData.movement,
                     
                     // Informações básicas
@@ -1046,6 +1048,16 @@ class OldDragon2eCharacterGenerator {
             };
 
             const actor = await Actor.create(actorData);
+            
+            // Força a atualização dos PV após a criação
+            await actor.update({
+                'system.pv': characterData.hitPoints,
+                'system.pv_max': characterData.hitPoints,
+                'system.hp': characterData.hitPoints,
+                'system.hp_max': characterData.hitPoints,
+                'system.hitPoints': characterData.hitPoints,
+                'system.hitPointsMax': characterData.hitPoints
+            });
             
             // Importa Raça e Classe do SRD como Itens do Ator
             try {

--- a/scripts/character-generator.js
+++ b/scripts/character-generator.js
@@ -960,6 +960,10 @@ class OldDragon2eCharacterGenerator {
             console.log('Debug PV - characterData.hitPoints:', characterData.hitPoints);
             console.log('Debug PV - characterData:', characterData);
             
+            // Debug: verifica a estrutura do sistema Old Dragon 2e
+            console.log('Debug - Sistema Old Dragon 2e:', game.system);
+            console.log('Debug - Template de personagem:', game.system.template?.Actor?.character);
+            
             // Cria o personagem com estrutura do sistema Old Dragon 2e
             const actorData = {
                 name: characterData.name,
@@ -1049,6 +1053,10 @@ class OldDragon2eCharacterGenerator {
 
             const actor = await Actor.create(actorData);
             
+            // Debug: verifica a estrutura do personagem criado
+            console.log('Debug - Personagem criado:', actor);
+            console.log('Debug - System do personagem:', actor.system);
+            
             // Força a atualização dos PV após a criação
             await actor.update({
                 'system.pv': characterData.hitPoints,
@@ -1058,6 +1066,9 @@ class OldDragon2eCharacterGenerator {
                 'system.hitPoints': characterData.hitPoints,
                 'system.hitPointsMax': characterData.hitPoints
             });
+            
+            // Debug: verifica se a atualização funcionou
+            console.log('Debug - PV após atualização:', actor.system.pv, actor.system.hp, actor.system.hitPoints);
             
             // Importa Raça e Classe do SRD como Itens do Ator
             try {

--- a/scripts/character-generator.js
+++ b/scripts/character-generator.js
@@ -956,6 +956,10 @@ class OldDragon2eCharacterGenerator {
             else if (raceName.includes('anão') || raceName.includes('anao')) jpRaceBonus = 'jpc';
             else if (raceName.includes('halfling')) jpRaceBonus = 'jps';
 
+            // Debug: verifica os PV antes de criar o personagem
+            console.log('Debug PV - characterData.hitPoints:', characterData.hitPoints);
+            console.log('Debug PV - characterData:', characterData);
+            
             // Cria o personagem com estrutura do sistema Old Dragon 2e
             const actorData = {
                 name: characterData.name,
@@ -996,6 +1000,8 @@ class OldDragon2eCharacterGenerator {
                     // Vida e Movimento
                     pv: characterData.hitPoints,
                     pv_max: characterData.hitPoints,
+                    hp: characterData.hitPoints,
+                    hp_max: characterData.hitPoints,
                     movimento: characterData.movement,
                     
                     // Informações básicas


### PR DESCRIPTION
## 🐛 Correção de Bug - Pontos de Vida (PV)

### **Problema Identificado**
O gerador de personagens estava calculando PV aleatoriamente (rolando o dado) em vez de usar o valor máximo do dado para o primeiro nível, conforme as regras do Old Dragon 2e. Além disso, os PV calculados não estavam sendo importados corretamente para a ficha do Foundry VTT.

### **Solução Implementada**

#### 1. **Correção do Cálculo de PV**
- **Antes**: `return Math.max(1, this.rollDie(die) + modifier)` (valor aleatório)
- **Depois**: `return Math.max(1, die + modifier)` (valor máximo do dado)

#### 2. **Correção da Estrutura de Dados**
- **Identificado**: Sistema Old Dragon 2e usa `hp: {value: X, max: X}`
- **Corrigido**: Removidos campos incorretos (`pv`, `pv_max`, `hitPoints`, etc.)
- **Implementado**: Estrutura correta `hp: {value: characterData.hitPoints, max: characterData.hitPoints}`

#### 3. **Limpeza do Código**
- Removidos todos os logs de debug desnecessários
- Removido código de atualização forçada desnecessário
- Código limpo e otimizado para produção

### **Resultado**
- **PV Corretos**: Guerreiro sempre tem 10+mod. Constituição (não mais 3-10)
- **Importação Funcionando**: PV exibidos na ficha correspondem aos calculados
- **Código Limpo**: Sem logs desnecessários poluindo o console

### **Classes e PV Máximos**
- **Guerreiro/Bárbaro/Paladino**: 10 + mod. Constituição
- **Clérigo/Druida**: 8 + mod. Constituição  
- **Ladino/Bardo**: 6 + mod. Constituição
- **Mago/Bruxo**: 4 + mod. Constituição

### **Arquivos Modificados**
- `scripts/character-generator.js`: Correção do cálculo e estrutura de PV
- `module.json`: Atualização da versão para 2.1.2

### **Testes**
✅ PV calculados corretamente no modal  
✅ PV importados corretamente para a ficha  
✅ Código limpo sem logs desnecessários  

---

**Versão**: 2.1.2  
**Tipo**: Bug Fix  
**Compatibilidade**: Foundry VTT v13+, Old Dragon 2e v2.2.0+