### PR TITLE
Corrige o ID do módulo para corresponder ao nome do repositório GitHub

### DIFF
--- a/PROJECT_SUMMARY.md
+++ b/PROJECT_SUMMARY.md
@@ -7,7 +7,7 @@ Criado um módulo completo para Foundry Virtual Tabletop que permite gerar perso
 ## Estrutura do Projeto
 
 ```
-old-dragon-2e-gerador-de-personagens/
+old-dragon-2e---gerador-de-personagens/
 ├── module.json                    # Manifesto principal do módulo
 ├── README.md                      # Documentação principal
 ├── EXAMPLES.md                    # Exemplos de uso

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ O módulo não requer configurações especiais. Ele funciona automaticamente co
 ## Estrutura do Projeto
 
 ```
-old-dragon-2e-gerador-de-personagens/
+old-dragon-2e---gerador-de-personagens/
 ├── module.json              # Configuração do módulo
 ├── scripts/
 │   ├── character-generator.js  # Lógica principal

--- a/module.json
+++ b/module.json
@@ -1,6 +1,6 @@
 {
   "title": "Old Dragon 2e - Gerador de Personagens",
-  "id": "old-dragon-2e-gerador-de-personagens",
+  "id": "old-dragon-2e---gerador-de-personagens",
   "description": "Um módulo para gerar personagens automaticamente para o sistema Old Dragon 2e. Permite criar personagens com atributos aleatórios, classes, raças e equipamentos seguindo as regras do sistema. Inclui arquitetura modular com classes especializadas para melhor organização e manutenibilidade.",
   "compatibility": {
     "minimum": 13,

--- a/scripts/settings.js
+++ b/scripts/settings.js
@@ -4,7 +4,7 @@
 
 Hooks.on('init', function() {
     // Registra as configurações do módulo
-    game.settings.register('old-dragon-2e-gerador-de-personagens', 'enableAutoGeneration', {
+    game.settings.register('old-dragon-2e---gerador-de-personagens', 'enableAutoGeneration', {
         name: 'Habilitar Geração Automática',
         hint: 'Permite gerar personagens automaticamente ao clicar no botão',
         scope: 'world',
@@ -13,7 +13,7 @@ Hooks.on('init', function() {
         default: true
     });
 
-    game.settings.register('old-dragon-2e-gerador-de-personagens', 'defaultLevel', {
+    game.settings.register('old-dragon-2e---gerador-de-personagens', 'defaultLevel', {
         name: 'Nível Padrão',
         hint: 'Nível inicial dos personagens gerados',
         scope: 'world',
@@ -27,7 +27,7 @@ Hooks.on('init', function() {
         }
     });
 
-    game.settings.register('old-dragon-2e-gerador-de-personagens', 'enableEquipment', {
+    game.settings.register('old-dragon-2e---gerador-de-personagens', 'enableEquipment', {
         name: 'Incluir Equipamento',
         hint: 'Adiciona equipamento básico aos personagens gerados',
         scope: 'world',
@@ -36,7 +36,7 @@ Hooks.on('init', function() {
         default: true
     });
 
-    game.settings.register('old-dragon-2e-gerador-de-personagens', 'enableNames', {
+    game.settings.register('old-dragon-2e---gerador-de-personagens', 'enableNames', {
         name: 'Gerar Nomes',
         hint: 'Gera nomes aleatórios para os personagens',
         scope: 'world',
@@ -45,7 +45,7 @@ Hooks.on('init', function() {
         default: true
     });
 
-    game.settings.register('old-dragon-2e-gerador-de-personagens', 'allowedRaces', {
+    game.settings.register('old-dragon-2e---gerador-de-personagens', 'allowedRaces', {
         name: 'Raças Permitidas',
         hint: 'Selecione quais raças podem ser geradas',
         scope: 'world',
@@ -62,7 +62,7 @@ Hooks.on('init', function() {
         }
     });
 
-    game.settings.register('old-dragon-2e-gerador-de-personagens', 'allowedClasses', {
+    game.settings.register('old-dragon-2e---gerador-de-personagens', 'allowedClasses', {
         name: 'Classes Permitidas',
         hint: 'Selecione quais classes podem ser geradas',
         scope: 'world',
@@ -80,7 +80,7 @@ Hooks.on('init', function() {
         }
     });
 
-    game.settings.register('old-dragon-2e-gerador-de-personagens', 'buttonPosition', {
+    game.settings.register('old-dragon-2e---gerador-de-personagens', 'buttonPosition', {
         name: 'Posição do Botão',
         hint: 'Onde o botão de geração deve aparecer',
         scope: 'world',
@@ -94,7 +94,7 @@ Hooks.on('init', function() {
         }
     });
 
-    game.settings.register('old-dragon-2e-gerador-de-personagens', 'buttonStyle', {
+    game.settings.register('old-dragon-2e---gerador-de-personagens', 'buttonStyle', {
         name: 'Estilo do Botão',
         hint: 'Aparência visual do botão de geração',
         scope: 'world',


### PR DESCRIPTION
## Descrição

Esta PR corrige o problema do nome da pasta que baixava com nome incorreto.

## Problema Identificado

O ID do módulo no `module.json` (`old-dragon-2e-gerador-de-personagens`) não correspondia ao nome do repositório GitHub (`Old-Dragon-2e---Gerador-de-Personagens`), causando inconsistência quando o módulo era baixado.

## Solução Implementada

- ✅ Atualizado o campo `id` no `module.json` para `old-dragon-2e---gerador-de-personagens`
- ✅ Atualizadas todas as referências ao ID antigo no `settings.js` (8 ocorrências)
- ✅ Atualizada a documentação nos arquivos `README.md` e `PROJECT_SUMMARY.md`

## Arquivos Modificados

- `module.json` - Atualizado o campo ID
- `scripts/settings.js` - Atualizadas todas as referências ao ID
- `README.md` - Atualizada a estrutura do projeto
- `PROJECT_SUMMARY.md` - Atualizada a estrutura do projeto

## Testes

- ✅ Verificado que não há erros de linting
- ✅ Confirmado que todas as referências foram atualizadas
- ✅ Testado que o novo ID está sendo usado corretamente

## Impacto

Esta correção garante que quando o módulo for baixado do GitHub, ele terá um nome consistente com o repositório, resolvendo o problema do nome da pasta incorreto.